### PR TITLE
Bb bom

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,1 @@
-IPS_VERSION=IPS-1.12.6
-
-CX_VERSION=CXS-6.2.10
-
-DBS_VERSION=DBS-2.19.3
-
-# Update the job.yaml accordingly based on CX bom on repo -https://repo.backbase.com/webapp/#/artifacts/browse/tree/PomView/backbase-6-release/com/backbase/cxp/cx-bom
+BB_VERSION=2021.07

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Update `.env` file for version.
 
 To run nested `docker-compose.yaml` from root:
 ```
-docker-compose -f <path-to-compose-file> up -d
+docker-compose --env-file .env -f <path-to-compose-file> up -d
 ```
+or just export `BB_VERSION` in your terminal.
 
 ## Provisioning Statics
 

--- a/content-approval/docker-compose.yaml
+++ b/content-approval/docker-compose.yaml
@@ -69,14 +69,14 @@ services:
       - demo_mysql_data:/var/lib/mysql
 
   registry:
-    image: repo.backbase.com/backbase-docker-releases/registry:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/registry:${BB_VERSION}
     ports:
       - "8761:8080"
     environment:
       <<: *sso-variables
 
   token-converter:
-    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${BB_VERSION}
     ports:
       - "7779:8080"
     environment:
@@ -88,7 +88,7 @@ services:
       - registry
 
   edge:
-    image: repo.backbase.com/backbase-docker-releases/edge:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/edge:${BB_VERSION}
     ports:
       - "8754:8080"
     environment:
@@ -100,7 +100,7 @@ services:
       - token-converter
 
   auth:
-    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${IPS_VERSION}-no-production
+    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${BB_VERSION}-no-production
     ports:
       - "7777:8080"
     environment:
@@ -122,7 +122,7 @@ services:
       - edge
 
   space-controller:
-    image: repo.backbase.com/backbase-docker-releases/space-controller:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/space-controller:${BB_VERSION}
     hostname: space-controller
     ports:
       - "8080:8080"
@@ -140,7 +140,7 @@ services:
       - mysql
 
   contentservices:
-    image: repo.backbase.com/backbase-docker-releases/contentservices:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/contentservices:${BB_VERSION}
     hostname: contentservices
     ports:
       - "8040:8080"
@@ -162,7 +162,7 @@ services:
       - message-broker
 
   portal:
-    image: repo.backbase.com/backbase-docker-releases/portal:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/portal:${BB_VERSION}
     hostname: portal
     ports:
       - "8070:8080"
@@ -188,7 +188,7 @@ services:
       - message-broker
 
   provisioning:
-    image: repo.backbase.com/backbase-docker-releases/provisioning:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/provisioning:${BB_VERSION}
     hostname: provisioning
     ports:
       - "8090:8080"

--- a/dbs-lean/docker-compose.yaml
+++ b/dbs-lean/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       - demo_mysql_data:/var/lib/mysql
 
   edge:
-    image: repo.backbase.com/backbase-docker-releases/edge:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/edge:${BB_VERSION}
     ports:
       - "8080:8080"
     environment:
@@ -62,12 +62,12 @@ services:
       - token-converter
   
   registry:
-    image: repo.backbase.com/backbase-docker-releases/registry:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/registry:${BB_VERSION}
     ports:
       - "8761:8080"
 
   token-converter:
-    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${BB_VERSION}
     ports:
       - "7779:8080"
     environment:
@@ -76,7 +76,7 @@ services:
       - registry
 
   auth:
-    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${IPS_VERSION}-no-production
+    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${BB_VERSION}-no-production
     ports:
       - "7778:8080"
     environment:
@@ -87,35 +87,35 @@ services:
       - message-broker
 
   contactmanager:
-    image: repo.backbase.com/backbase-docker-releases/contact-manager:${DBS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/contact-manager:${BB_VERSION}
     ports:
       - "8010:8080"
     environment:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/contact?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/contact?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry
       - message-broker
 
   approval:
-    image: repo.backbase.com/backbase-docker-releases/approval-service:${DBS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/approval-service:${BB_VERSION}
     ports:
       - "8020:8080"
     environment:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/approval?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/approval?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry
       - message-broker
 
   paymentorder:
-    image: repo.backbase.com/backbase-docker-releases/payment-order-service:${DBS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/payment-order-service:${BB_VERSION}
     ports:
       - "8030:8080"
     environment:
@@ -124,21 +124,21 @@ services:
       <<: *database-variables
       portal.resource-location.profile: filesystem
       portal.resource-location.path: /tmp
-      spring.datasource.url: jdbc:mysql://mysql:3306/payment?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/payment?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry
       - message-broker
 
   message:
-    image: repo.backbase.com/backbase-docker-releases/messages-service:${DBS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/messages-service:${BB_VERSION}
     ports:
       - "8040:8080"
     environment:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/message?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/message?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
       MESSAGING_PASSWORD: password
     links:
       - mysql
@@ -146,14 +146,14 @@ services:
       - message-broker
 
   notification:
-    image: repo.backbase.com/backbase-docker-releases/notifications-service:${DBS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/notifications-service:${BB_VERSION}
     ports:
       - "8050:8080"
     environment:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/notification?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/notification?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       - demo_mysql_data:/var/lib/mysql
 
   edge:
-    image: repo.backbase.com/backbase-docker-releases/edge:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/edge:${BB_VERSION}
     ports:
       - "8080:8080"
     environment:
@@ -62,12 +62,12 @@ services:
       - token-converter
   
   registry:
-    image: repo.backbase.com/backbase-docker-releases/registry:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/registry:${BB_VERSION}
     ports:
       - "8761:8080"
 
   token-converter:
-    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${BB_VERSION}
     ports:
       - "7779:8080"
     environment:
@@ -76,7 +76,7 @@ services:
       - registry
 
   auth:
-    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${IPS_VERSION}-no-production
+    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${BB_VERSION}-no-production
     ports:
       - "7778:8080"
     environment:
@@ -87,7 +87,7 @@ services:
       - message-broker
 
   contentservices:
-    image: repo.backbase.com/backbase-docker-releases/contentservices:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/contentservices:${BB_VERSION}
     hostname: contentservices
     ports:
       - "8040:8080"
@@ -95,14 +95,14 @@ services:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/cs?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/cs?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry
       - message-broker
 
   portal:
-    image: repo.backbase.com/backbase-docker-releases/portal:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/portal:${BB_VERSION}
     hostname: portal
     ports:
       - "8070:8080"
@@ -112,7 +112,7 @@ services:
       <<: *database-variables
       portal.resource-location.profile: filesystem
       portal.resource-location.path: /tmp
-      spring.datasource.url: jdbc:mysql://mysql:3306/portal?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/portal?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
       spring.jpa.properties.hibernate.session_factory_name_is_jndi: 'false'
     links:
       - mysql
@@ -121,7 +121,7 @@ services:
       - message-broker
 
   provisioning:
-    image: repo.backbase.com/backbase-docker-releases/provisioning:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/provisioning:${BB_VERSION}
     hostname: provisioning
     ports:
       - "8090:8080"
@@ -129,7 +129,7 @@ services:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/provisioning?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/provisioning?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry

--- a/identity/docker-compose.yaml
+++ b/identity/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       - demo_mysql_data:/var/lib/mysql
 
   edge:
-    image: repo.backbase.com/backbase-docker-releases/edge:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/edge:${BB_VERSION}
     ports:
       - "8080:8080"
     environment:
@@ -62,12 +62,12 @@ services:
       - token-converter
   
   registry:
-    image: repo.backbase.com/backbase-docker-releases/registry:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/registry:${BB_VERSION}
     ports:
       - "8761:8080"
 
   token-converter:
-    image: repo.backbase.com/backbase-docker-releases/oidc-token-converter-service:IDENTITY-1.6.0.1-latest
+    image: repo.backbase.com/backbase-docker-releases/oidc-token-converter-service:${BB_VERSION}
     ports:
       - "7779:8080"
     environment:
@@ -76,11 +76,11 @@ services:
       - registry
 
   identity:
-    image: repo.backbase.com/backbase-docker-releases/backbase-identity:IDENTITY-1.6.0.1-latest
+    image: repo.backbase.com/backbase-docker-releases/backbase-identity:${BB_VERSION}
     ports:
       - "9090:8080"
     environment:
-      QUARKUS_DATASOURCE_URL: jdbc:mysql://mysql:3306/identity?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      QUARKUS_DATASOURCE_URL: jdbc:mysql://mysql:3306/identity?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
       QUARKUS_DATASOURCE_DRIVER: com.mysql.jdbc.Driver
       QUARKUS_DATASOURCE_USERNAME: root
       QUARKUS_DATASOURCE_PASSWORD: root
@@ -107,7 +107,7 @@ services:
       - ./json:/tmp/keycloak-export
 
   contentservices:
-    image: repo.backbase.com/backbase-docker-releases/contentservices:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/contentservices:${BB_VERSION}
     hostname: contentservices
     ports:
       - "8040:8080"
@@ -115,14 +115,14 @@ services:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/cs?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/cs?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry
       - message-broker
 
   portal:
-    image: repo.backbase.com/backbase-docker-releases/portal:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/portal:${BB_VERSION}
     hostname: portal
     ports:
       - "8070:8080"
@@ -132,7 +132,7 @@ services:
       <<: *database-variables
       portal.resource-location.profile: filesystem
       portal.resource-location.path: /tmp
-      spring.datasource.url: jdbc:mysql://mysql:3306/portal?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/portal?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
       spring.jpa.properties.hibernate.session_factory_name_is_jndi: 'false'
     links:
       - mysql
@@ -141,7 +141,7 @@ services:
       - message-broker
 
   provisioning:
-    image: repo.backbase.com/backbase-docker-releases/provisioning:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/provisioning:${BB_VERSION}
     hostname: provisioning
     ports:
       - "8090:8080"
@@ -149,7 +149,7 @@ services:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/provisioning?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/provisioning?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry

--- a/job.yaml
+++ b/job.yaml
@@ -8,7 +8,7 @@ imports:
     username: <yourRepoUsername>
     password: <yourRepoPassword>
     statics:
-      - /backbase-6-release/com/backbase/tools/provisioner/7.0.0-b2/provisioner-7.0.0-b2.jar
+      - /backbase-6-release/com/backbase/tools/provisioner-cli/7.0.0-b2/provisioner-cli-7.0.0-b2.jar
       - /backbase-6-release/com/backbase/cxp/editorial-collection/2.23.0-b21/editorial-collection-2.23.0-b21.zip
       - /expert-release-local/com/backbase/web-sdk/collection/collection-bb-web-sdk/1.16.1/collection-bb-web-sdk-1.16.1.zip
       - /backbase-6-release/com/backbase/cxp/experience-manager/2.23.0-b21/experience-manager-2.23.0-b21.zip

--- a/job.yaml
+++ b/job.yaml
@@ -8,10 +8,10 @@ imports:
     username: <yourRepoUsername>
     password: <yourRepoPassword>
     statics:
-      - /backbase-6-release/com/backbase/tools/cx/cx6-import-tool-cli/6.2.10-b1/cx6-import-tool-cli-6.2.10-b1.jar
-      - /backbase-6-release/com/backbase/cxp/editorial-collection/2.0.0-b340/editorial-collection-2.0.0-b340.zip
-      - /expert-release-local/com/backbase/web-sdk/collection/collection-bb-web-sdk/1.14.0/collection-bb-web-sdk-1.14.0.zip
-      - /backbase-6-release/com/backbase/cxp/experience-manager/2.0.0-b340/experience-manager-2.0.0-b340.zip
+      - /backbase-6-release/com/backbase/tools/provisioner/7.0.0-b2/provisioner-7.0.0-b2.jar
+      - /backbase-6-release/com/backbase/cxp/editorial-collection/2.23.0-b21/editorial-collection-2.23.0-b21.zip
+      - /expert-release-local/com/backbase/web-sdk/collection/collection-bb-web-sdk/1.16.1/collection-bb-web-sdk-1.16.1.zip
+      - /backbase-6-release/com/backbase/cxp/experience-manager/2.23.0-b21/experience-manager-2.23.0-b21.zip
 target:
   context: http://edge:8080/api/provisioning
   auth-url: http://edge:8080/api/auth/login

--- a/kafka/docker-compose.yaml
+++ b/kafka/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
       - demo_mysql_data:/var/lib/mysql
 
   edge:
-    image: repo.backbase.com/backbase-docker-releases/edge:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/edge:${BB_VERSION}
     ports:
       - "8080:8080"
     environment:
@@ -83,12 +83,12 @@ services:
       - token-converter
   
   registry:
-    image: repo.backbase.com/backbase-docker-releases/registry:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/registry:${BB_VERSION}
     ports:
       - "8761:8080"
 
   token-converter:
-    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${IPS_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${BB_VERSION}
     ports:
       - "7779:8080"
     environment:
@@ -97,7 +97,7 @@ services:
       - registry
 
   auth:
-    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${IPS_VERSION}-no-production
+    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${BB_VERSION}-no-production
     ports:
       - "7778:8080"
     environment:
@@ -111,7 +111,7 @@ services:
       - message-broker
 
   contentservices:
-    image: repo.backbase.com/backbase-docker-releases/contentservices:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/contentservices:${BB_VERSION}
     hostname: contentservices
     ports:
       - "8040:8080"
@@ -119,14 +119,14 @@ services:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/cs?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/cs?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry
       - message-broker
 
   portal:
-    image: repo.backbase.com/backbase-docker-releases/portal:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/portal:${BB_VERSION}
     hostname: portal
     ports:
       - "8070:8080"
@@ -136,7 +136,7 @@ services:
       <<: *database-variables
       portal.resource-location.profile: filesystem
       portal.resource-location.path: /tmp
-      spring.datasource.url: jdbc:mysql://mysql:3306/portal?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/portal?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
       spring.jpa.properties.hibernate.session_factory_name_is_jndi: 'false'
     links:
       - mysql
@@ -145,7 +145,7 @@ services:
       - message-broker
 
   provisioning:
-    image: repo.backbase.com/backbase-docker-releases/provisioning:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/provisioning:${BB_VERSION}
     hostname: provisioning
     ports:
       - "8090:8080"
@@ -153,7 +153,7 @@ services:
       <<: *common-variables
       <<: *message-broker-variables
       <<: *database-variables
-      spring.datasource.url: jdbc:mysql://mysql:3306/provisioning?cacheServerConfiguration=true&createDatabaseIfNotExist=true
+      spring.datasource.url: jdbc:mysql://mysql:3306/provisioning?useSSL=false&cacheServerConfiguration=true&createDatabaseIfNotExist=true
     links:
       - mysql
       - registry

--- a/rabbitmq/docker-compose.yaml
+++ b/rabbitmq/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - demo_mysql_data:/var/lib/mysql
 
   edge:
-    image: repo.backbase.com/backbase-docker-releases/edge:IPS-1.12.6
+    image: repo.backbase.com/backbase-docker-releases/edge:${BB_VERSION}
     hostname: edge
     ports:
       - "8080:8080"
@@ -68,12 +68,12 @@ services:
       - token-converter
   
   registry:
-    image: repo.backbase.com/backbase-docker-releases/registry:IPS-1.12.6
+    image: repo.backbase.com/backbase-docker-releases/registry:${BB_VERSION}
     ports:
       - "8761:8080"
 
   token-converter:
-    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:IPS-1.12.6
+    image: repo.backbase.com/backbase-docker-releases/bb-authentication-token-converter-service:${BB_VERSION}
     ports:
       - "7779:8080"
     environment:
@@ -82,7 +82,7 @@ services:
       - registry
 
   auth:
-    image: repo.backbase.com/backbase-docker-releases/authentication-dev:IPS-1.12.6-no-production
+    image: repo.backbase.com/backbase-docker-releases/authentication-dev:${BB_VERSION}-no-production
     ports:
       - "7778:8080"
     environment:
@@ -96,7 +96,7 @@ services:
       - message-broker
 
   contentservices:
-    image: repo.backbase.com/backbase-docker-releases/contentservices:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/contentservices:${BB_VERSION}
     hostname: contentservices
     ports:
       - "8040:8080"
@@ -111,7 +111,7 @@ services:
       - message-broker
 
   portal:
-    image: repo.backbase.com/backbase-docker-releases/portal:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/portal:${BB_VERSION}
     hostname: portal
     ports:
       - "8070:8080"
@@ -130,7 +130,7 @@ services:
       - message-broker
 
   provisioning:
-    image: repo.backbase.com/backbase-docker-releases/provisioning:${CX_VERSION}
+    image: repo.backbase.com/backbase-docker-releases/provisioning:${BB_VERSION}
     hostname: provisioning
     ports:
       - "8090:8080"


### PR DESCRIPTION
In docker-compose example we use `import-statics` (updated last dec) to provision. Its fails even for  provisioner-cli-7.0.0-b2.jar, probably because of the java 11 change.
But in general, provisioning works with standard scripts and other ways we normally use. SDLC/backbase-statics image is not something we officially ship to repo.